### PR TITLE
Release 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Capacitor Plugin Changelog
 
+## Version 2.0.1 July 16, 2024
+Patch release that fixes a critical issue with iOS that prevents the Airship library from automatically initializing. Apps using 2.0.0 should update.
+
+### Changes
+- Added missing files to the npm package for iOS
+
 ## Version 2.0.0 July 2, 2024
 Major release to support Capacitor 6.
 

--- a/android/src/main/java/com/airship/capacitor/AirshipCapacitorVersion.kt
+++ b/android/src/main/java/com/airship/capacitor/AirshipCapacitorVersion.kt
@@ -3,5 +3,5 @@
 package com.airship.capacitor
 
 object AirshipCapacitorVersion {
-    var version = "2.0.0"
+    var version = "2.0.1"
 }

--- a/ios/Plugin/AirshipCapacitorVersion.swift
+++ b/ios/Plugin/AirshipCapacitorVersion.swift
@@ -3,5 +3,5 @@
 import Foundation
 
 class AirshipCapacitorVersion {
-    static let version = "2.0.0"
+    static let version = "2.0.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ua/capacitor-airship",
-  "version": "1.2.4",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ua/capacitor-airship",
-      "version": "1.2.4",
+      "version": "2.0.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@capacitor/android": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ua/capacitor-airship",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Airship capacitor plugin",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",
@@ -11,6 +11,7 @@
     "android/build.gradle",
     "dist/",
     "ios/Plugin/",
+    "ios/Bootloader/",
     "UaCapacitorAirship.podspec"
   ],
   "author": "Airship",


### PR DESCRIPTION
Running npm pack:

before
```
npm notice 3.0kB  ios/Plugin/AirshipCapacitorAutopilot.swift                            
npm notice 128B   ios/Plugin/AirshipCapacitorVersion.swift                              
npm notice 18.0kB ios/Plugin/AirshipPlugin.swift  
```

after
```
npm notice 786B   ios/Bootloader/AirshipCapacitorBootstrap.m                            
npm notice 131B   ios/Bootloader/Public/AirshipCapacitorBootstrap.h                     
npm notice 3.0kB  ios/Plugin/AirshipCapacitorAutopilot.swift                            
npm notice 128B   ios/Plugin/AirshipCapacitorVersion.swift                              
npm notice 18.0kB ios/Plugin/AirshipPlugin.swift   
```