### PR TITLE
Upload docs to GitHub Pages

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,3 +74,22 @@ jobs:
         uses: google-github-actions/setup-gcloud@v1
       - name: Upload Docs
         run: bash ./scripts/upload_docs.sh ${GITHUB_REF/refs\/tags\//} ./docs
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+  deploy-docs:
+    needs: deploy
+    runs-on: ubuntu-latest
+    continue-on-error: true # Remove when migration to GH Pages is complete
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### What do these changes do?

Updates the release workflow with a new step in the `docs` job that uploads an artifact for pages and adds a new step, `deploy-docs` that deploys the uploaded artifact to GitHub Pages.

### Why are these changes necessary?

API docs migration

### How did you verify these changes?

We're getting all the repos ready before enabling pages, so we'll have to wait and see. In the meantime, we have `continue-on-error: true`, so failures shouldn't impact anything.
