### PR TITLE
Release 5.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Capacitor Plugin Changelog
 
+## Version 5.5.1 - May 6, 2026
+
+Patch release that fixes `Package.swift` not being included in the published npm package.
+
+### Changes
+- Fixed `Package.swift` missing from the published npm package
+
 ## Version 5.5.0 - May 1, 2026
 
 Minor release that updates the Android SDK to 20.7.0 and the iOS SDK to 20.7.0.

--- a/android/src/main/java/com/airship/capacitor/AirshipCapacitorVersion.kt
+++ b/android/src/main/java/com/airship/capacitor/AirshipCapacitorVersion.kt
@@ -3,5 +3,5 @@
 package com.airship.capacitor
 
 object AirshipCapacitorVersion {
-    var version = "5.5.0"
+    var version = "5.5.1"
 }

--- a/ios/Plugin/AirshipCapacitorVersion.swift
+++ b/ios/Plugin/AirshipCapacitorVersion.swift
@@ -3,5 +3,5 @@
 import Foundation
 
 class AirshipCapacitorVersion {
-    static let version = "5.5.0"
+    static let version = "5.5.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ua/capacitor-airship",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ua/capacitor-airship",
-      "version": "5.5.0",
+      "version": "5.5.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@capacitor/android": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ua/capacitor-airship",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "description": "Airship capacitor plugin",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",
@@ -12,6 +12,7 @@
     "dist/",
     "ios/Plugin/",
     "ios/Bootloader/",
+    "Package.swift",
     "UaCapacitorAirship.podspec"
   ],
   "author": "Airship",


### PR DESCRIPTION
## Summary
- Bumps version to 5.5.1
- Fixes `Package.swift` missing from the published npm package by adding it to the `files` array
