### PR TITLE
Extract docs publishing into reusable workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,74 @@
+name: Publish Docs
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+    secrets:
+      GCP_SA_KEY:
+        required: true
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag to publish docs for (e.g. 12.0.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  release-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.version }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: https://registry.npmjs.org/
+
+      - name: Install dependencies
+        run: npm install --no-save --registry=https://registry.npmjs.org/
+
+      - name: Build docs
+        run: npm run build:docs
+
+      - name: Setup GCP Auth
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+      - name: Upload Docs
+        env:
+          VERSION: ${{ inputs.version }}
+        run: bash ./scripts/upload_docs.sh "$VERSION" ./docs
+
+  deploy-docs:
+    needs: release-docs
+    runs-on: ubuntu-latest
+    continue-on-error: true # Remove when migration to GH Pages is complete
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,30 +66,14 @@ jobs:
           body: ${{ steps.get_release_notes.outputs.NOTES }}
           draft: false
           prerelease: false
-      - name: Setup GCP Auth
-        uses: google-github-actions/auth@v1
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-      - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v1
-      - name: Upload Docs
-        run: bash ./scripts/upload_docs.sh ${GITHUB_REF/refs\/tags\//} ./docs
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: docs
 
-  deploy-docs:
+  publish-docs:
     needs: deploy
-    runs-on: ubuntu-latest
-    continue-on-error: true # Remove when migration to GH Pages is complete
+    uses: ./.github/workflows/publish-docs.yml
+    with:
+      version: ${{ github.ref_name }}
+    secrets: inherit
     permissions:
+      contents: read
       pages: write
       id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- Extracts doc build/upload/Pages deployment out of the `deploy` job in `release.yaml` into a new reusable workflow at `.github/workflows/publish-docs.yml`
- `publish-docs.yml` supports two triggers: `workflow_call` (called automatically on tag push by the release workflow) and `workflow_dispatch` (manual reruns to republish docs for any existing tag)
- Fixes shell injection risk in the `Upload Docs` step by passing version through an env var
- Moves `Upload Pages artifact` before `Upload Docs` so the GCS tarball is never bundled into the Pages artifact
- Scopes `pages: write` to the `publish-docs` caller job only (not the top-level release workflow permissions)

## Test plan

- [ ] Verify the release workflow runs end-to-end on the next tag push (docs upload to GCS + GitHub Pages deploy)
- [ ] Manually trigger **Actions → Publish Docs → Run workflow** with an existing version tag to confirm the `workflow_dispatch` path works

🤖 Generated with [Claude Code](https://claude.com/claude-code)