### PR TITLE
Release 6.1.0

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -30,7 +30,7 @@ jobs:
         run: |
           set -eo pipefail
           npm install --no-save --registry=https://registry.npmjs.org/
-          npm run verify | xcpretty --color
+          npm run verify
       - name: Build example iOS app
         run: |
           set -eo pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Capacitor Plugin Changelog
 
+## Version 6.1.0 - June 12, 2026
+
+Minor release that updates the Android SDK to 20.7.4 and the iOS SDK to 20.7.2.
+
+### Changes
+- Updated Android SDK to [20.7.4](https://github.com/urbanairship/android-library/releases/tag/20.7.4)
+- Updated iOS SDK to [20.7.2](https://github.com/urbanairship/ios-library/releases/tag/20.7.2)
+
+
 ## Version 6.0.0 - May 7, 2026
 
 Major release that updates Capacitor to 8.0.

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0"),
-        .package(url: "https://github.com/urbanairship/airship-mobile-framework-proxy.git", from: "15.9.0")
+        .package(url: "https://github.com/urbanairship/airship-mobile-framework-proxy.git", from: "15.9.1")
     ],
     targets: [
          .target(

--- a/UaCapacitorAirship.podspec
+++ b/UaCapacitorAirship.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '16.0'
   s.dependency 'Capacitor'
   s.swift_version = '6'
-  s.dependency "AirshipFrameworkProxy", "15.9.0"
+  s.dependency "AirshipFrameworkProxy", "15.9.1"
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    airshipProxyVersion = project.hasProperty('airshipProxyVersion') ? rootProject.ext.airshipProxyVersion : '15.9.0'
+    airshipProxyVersion = project.hasProperty('airshipProxyVersion') ? rootProject.ext.airshipProxyVersion : '15.9.1'
 }
 
 

--- a/android/src/main/java/com/airship/capacitor/AirshipCapacitorVersion.kt
+++ b/android/src/main/java/com/airship/capacitor/AirshipCapacitorVersion.kt
@@ -3,5 +3,5 @@
 package com.airship.capacitor
 
 object AirshipCapacitorVersion {
-    var version = "6.0.0"
+    var version = "6.1.0"
 }

--- a/ios/Plugin/AirshipCapacitorVersion.swift
+++ b/ios/Plugin/AirshipCapacitorVersion.swift
@@ -3,5 +3,5 @@
 import Foundation
 
 class AirshipCapacitorVersion {
-    static let version = "6.0.0"
+    static let version = "6.1.0"
 }

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -5,7 +5,7 @@ def capacitor_pods
   use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
-  pod 'AirshipFrameworkProxy', '15.9.0'
+  pod 'AirshipFrameworkProxy', '15.9.1'
 end
 
 target 'Plugin' do

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ua/capacitor-airship",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ua/capacitor-airship",
-      "version": "6.0.0",
+      "version": "6.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@capacitor/android": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ua/capacitor-airship",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "Airship capacitor plugin",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
Automated release preparation for Capacitor v6.1.0

## Version Updates
- Plugin: 6.1.0
- Framework Proxy: 15.9.1
- iOS SDK: 20.7.2
- Android SDK: 20.7.4

## Validation Reminder
⚠️ **Note:** Since this release updates the underlying native SDKs, the changelog entries across all framework plugins will be similar. This is expected and correct.

## Changed Files
```
CHANGELOG.md
Package.swift
UaCapacitorAirship.podspec
android/build.gradle
android/src/main/java/com/airship/capacitor/AirshipCapacitorVersion.kt
ios/Plugin/AirshipCapacitorVersion.swift
ios/Podfile
package-lock.json
package.json
```

## Next Steps
1. Review version updates
2. Verify changelog accuracy
3. Merge when ready

---
🤖 Generated by centralized release automation