### PR TITLE
[MOBILE-5697] Add keep rules for resources

### DIFF
--- a/android/src/main/res/raw/ua_capacitor_keep.xml
+++ b/android/src/main/res/raw/ua_capacitor_keep.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Resource keep rules for the Airship Capacitor plugin. -->
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="
+        @layout/ua_*,
+        @menu/ua_*,
+        @drawable/ua_*,
+        @string/ua_*,
+        @color/ua_message_center_*,
+        @style/UrbanAirship_MessageCenter*,
+        @attr/messageCenter*,
+        @id/mark_all_read,
+        @id/enter_edit_mode,
+        @id/leave_edit_mode,
+        @id/delete_all,
+        @id/delete,
+        @id/refresh,
+        @id/toolbar,
+        @id/list_vertical_divider" />


### PR DESCRIPTION
### What do these changes do?
Adds rules to prevent the Android resource shrinker from stripping Airship Message Center resources that are accessed programmatically at runtime.

### Why are these changes necessary?
To fix NoSuchFieldError crashes at runtime when minifyEnabled and shrinkResources are both enabled