### PR TITLE
Release 6.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,15 @@
 
 ## Version 6.2.0 - July 23, 2026
 
-Minor release that updates the Android SDK to 20.10.0 and the iOS SDK to 20.11.0.
-
-### Changes
-- Updated Android SDK to [20.10.0](https://github.com/urbanairship/android-library/releases/tag/20.10.0)
-- Updated iOS SDK to [20.11.0](https://github.com/urbanairship/ios-library/releases/tag/20.11.0)
-
-
-## Version 6.2.0 - Unreleased
-
-Minor release that adds support for Embedded Content.
+Minor release that adds support for Embedded Content and updates the iOS SDK to 20.11.0 and the Android SDK to 20.10.0.
 
 ### Changes
 - Added `Airship.inApp.addEmbeddedReadyListener` and `Airship.inApp.isEmbeddedReady` to track when embedded content is available for an embedded ID
 - Added `Airship.inApp.createEmbeddedView` to display embedded Scene content inline by overlaying a native view on a placeholder element
 - Added an optional `clipElement` to `createEmbeddedView` that clips the native view to a scroll container's bounds, so it scrolls under surrounding content (such as a header) instead of over it
+- Updated iOS SDK to [20.11.0](https://github.com/urbanairship/ios-library/releases/tag/20.11.0)
+- Updated Android SDK to [20.10.0](https://github.com/urbanairship/android-library/releases/tag/20.10.0)
+- Fixed iOS Message Center inbox failing to load after upgrading across SDK versions that changed the Core Data model
 
 ## Version 6.1.0 - June 12, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Capacitor Plugin Changelog
 
+## Version 6.2.0 - July 23, 2026
+
+Minor release that updates the Android SDK to 20.10.0 and the iOS SDK to 20.11.0.
+
+### Changes
+- Updated Android SDK to [20.10.0](https://github.com/urbanairship/android-library/releases/tag/20.10.0)
+- Updated iOS SDK to [20.11.0](https://github.com/urbanairship/ios-library/releases/tag/20.11.0)
+
+
 ## Version 6.2.0 - Unreleased
 
 Minor release that adds support for Embedded Content.

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0"),
-        .package(url: "https://github.com/urbanairship/airship-mobile-framework-proxy.git", from: "15.9.1")
+        .package(url: "https://github.com/urbanairship/airship-mobile-framework-proxy.git", from: "15.13.0")
     ],
     targets: [
          .target(

--- a/UaCapacitorAirship.podspec
+++ b/UaCapacitorAirship.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '16.0'
   s.dependency 'Capacitor'
   s.swift_version = '6'
-  s.dependency "AirshipFrameworkProxy", "15.9.1"
+  s.dependency "AirshipFrameworkProxy", "15.13.0"
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    airshipProxyVersion = project.hasProperty('airshipProxyVersion') ? rootProject.ext.airshipProxyVersion : '15.9.1'
+    airshipProxyVersion = project.hasProperty('airshipProxyVersion') ? rootProject.ext.airshipProxyVersion : '15.13.0'
 }
 
 

--- a/android/src/main/java/com/airship/capacitor/AirshipCapacitorVersion.kt
+++ b/android/src/main/java/com/airship/capacitor/AirshipCapacitorVersion.kt
@@ -3,5 +3,5 @@
 package com.airship.capacitor
 
 object AirshipCapacitorVersion {
-    var version = "6.1.0"
+    var version = "6.2.0"
 }

--- a/ios/Plugin/AirshipCapacitorVersion.swift
+++ b/ios/Plugin/AirshipCapacitorVersion.swift
@@ -3,5 +3,5 @@
 import Foundation
 
 class AirshipCapacitorVersion {
-    static let version = "6.1.0"
+    static let version = "6.2.0"
 }

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -5,7 +5,7 @@ def capacitor_pods
   use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
-  pod 'AirshipFrameworkProxy', '15.9.1'
+  pod 'AirshipFrameworkProxy', '15.13.0'
 end
 
 target 'Plugin' do

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ua/capacitor-airship",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ua/capacitor-airship",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@capacitor/android": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ua/capacitor-airship",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "Airship capacitor plugin",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
Automated release preparation for Capacitor v6.2.0

## Version Updates
- Plugin: 6.2.0
- Framework Proxy: 15.13.0
- iOS SDK: 20.11.0
- Android SDK: 20.10.0

## Validation Reminder
⚠️ **Note:** Since this release updates the underlying native SDKs, the changelog entries across all framework plugins will be similar. This is expected and correct.

## Changed Files
```
CHANGELOG.md
Package.swift
UaCapacitorAirship.podspec
android/build.gradle
android/src/main/java/com/airship/capacitor/AirshipCapacitorVersion.kt
ios/Plugin/AirshipCapacitorVersion.swift
ios/Podfile
package-lock.json
package.json
```

## Next Steps
1. Review version updates
2. Verify changelog accuracy
3. Merge when ready

---
🤖 Generated by centralized release automation